### PR TITLE
Added key to contributors list by using github id

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -137,8 +137,9 @@ const Layout = props => {
         </p>
         <div>
           {contributors.map(
-            ({ login, avatar_url, html_url }) => (
+            ({ login, avatar_url, html_url, id }) => (
               <a
+                key={id}
                 href={html_url}
                 style={{ boxShadow: 'none' }}
               >


### PR DESCRIPTION
Small fix for contributors does not have `key`

In Dev mode
![image](https://user-images.githubusercontent.com/9023187/66250487-cabbb580-e775-11e9-9b7d-767b967647a1.png)
