### PR TITLE
Update Batman/vs Superman Question with appropriate string

### DIFF
--- a/content/questions/batman-v-superman/index.md
+++ b/content/questions/batman-v-superman/index.md
@@ -6,9 +6,9 @@ tags:
 order: 15
 date: '2019-09-29'
 answers:
-  - 'Batman'
-  - 'Superman'
-  - 'Batman Superman // correct'
+  - '"Batman"'
+  - '"Superman"'
+  - '"BatmanSuperman" // correct'
   - 'Nothing gets logged'
 ---
 


### PR DESCRIPTION
The provided function for this question doesn't log an empty space between the two strings for the right answer. This fix removes that empty space to be more correct, otherwise people might get a little confused.

Love this platform, by the way! 