### PR TITLE
Add explanation

### DIFF
--- a/content/questions/short-circuit-notifications/index.md
+++ b/content/questions/short-circuit-notifications/index.md
@@ -23,4 +23,4 @@ console.log(
 
 <!-- explanation -->
 
-Unfortunately, our short-circuit evaluation will not work as intended here: `notifications !== 1 && 's'` evaluates to `false`, meaning we will actually be logging `You have 1 notificationfalse`. If we want our snippet to work correctly, we could consider a ternary operator.
+Short-hand notation for `false && something` would not see what is `something` and evaluate it as false.  Here `notifications !== 1` is `false`.  So, unfortunately, our short-circuit evaluation will not work as intended here: `notifications !== 1 && 's'` evaluates to `false`, meaning we will actually be logging `You have 1 notificationfalse`. If we want our snippet to work correctly, we could consider a ternary operator.


### PR DESCRIPTION
> unfortunately, our short-circuit evaluation will not work as intended here.
Actually, short-circuit evaluation is working as expected: the intention of the coder would be improperly met, and hence, an explanation before talking about intentions.