### PR TITLE
Fix grammar, spelling, style, wording, improve explanations

### DIFF
--- a/content/questions/Array-Method-findIndex/index.md
+++ b/content/questions/Array-Method-findIndex/index.md
@@ -9,7 +9,7 @@ answers:
   - 'False // correct'
 ---
 
-True or False: when using `array.findIndex` it will return 0 indicating that no element passed the test.
+True or False: `array.findIndex` will return 0 when no elements pass the test.
 
 <!-- explanation -->
 `findIndex` will actually return a `-1` since `0` would be a legitimate array index! 

--- a/content/questions/Array_Object/index.md
+++ b/content/questions/Array_Object/index.md
@@ -12,8 +12,8 @@ answers:
   - concat()
 ---
 
-What of the following array methods is guaranteed to iterate through each element of an array?
+Which of the following array methods is guaranteed to iterate through each element of an array?
 
 <!-- explanation -->
 
-`forEach()` calls a provided callback function once for each element in an array in ascending order. `every()` will stop as soon as the provided function results in a falsey condition. `concat()` simple combines two arrays.
+`forEach()` calls a provided callback function once for each element in an array in ascending order. `every()` will stop as soon as the provided function results in a falsey condition. `concat()` simply combines two arrays.

--- a/content/questions/array-as-boolean/index.md
+++ b/content/questions/array-as-boolean/index.md
@@ -13,21 +13,24 @@ answers:
   - '[true, false]'
   - '[false, false]'
 ---
-What does this snippet of code returns?
+
+What does the below function return?
 
 ```javascript
-function ArrayBolean(){
+function ArrayBoolean(){
   if([] && [1])
-    return [true, true]
+    return [true, true];
   else if([] && ![1])
-    return [true,false]
+    return [true,false];
   else if(![] && [1])
-    return [false,true]
+    return [false,true];
   else
-    return [false,false]
+    return [false,false];
 }
-ArrayBolean()
+ArrayBoolean();
 ```
 
 <!-- explanation -->
-In javascript both empty and non empty arrays are evaluated as true if they are not compared to a boolean, otherwise `[] == false` would evaluate to `true` because of the boolean comparison.
+In JavaScript, both empty and non empty arrays are truthy, like all objects. This is not the same thing as comparison - for example, if the arrays were loosely compared to a Boolean, the results would be different. `[] == false` would evaluate to `true` because the empty array, when converted into a primitive, is falsey.
+
+The first `if` statement is fulfilled, so `[true, true]` is returned.

--- a/content/questions/array-compare-2/index.md
+++ b/content/questions/array-compare-2/index.md
@@ -26,6 +26,6 @@ console.log(a < b);
 
 <!-- explanation -->
 
-When using `==` to compare an array with a number, JavaScript coerces the array to a number, which results in the first element in the array being converted to a number (`[9]` -> `9`). Therefore `9 == 9` and `10 == 10` are both `true`.
+When using `==` to compare an array with a number, JavaScript tries to coerce the array to a number, which is possible when the array contains a single numeric value. Here, `[9]` turns into `9`, and `[10]` turns into `10`, and `9 == 9` and `10 == 10` are both `true`.
 
-When comparing arrays with `<` or `>`, the arrays are instead coerced to strings (`[9]` -> `"9"`). When comparing strings, JavaScript uses lexicographical order, which means the strings are compared to each other 1 character at a time. Therefore the first comparison is `"9" < "1"`, which is false.
+When comparing arrays with `<` or `>`, the arrays are instead coerced to strings (`[9] < [10]` turns into `'9' < '10'`). When comparing strings, JavaScript uses lexicographical order, which means the strings are compared to each other one character at a time. The first characters that are different are the ones at the `[0]`th index, so the comparison done is `"9" < "1"`, which is false.

--- a/content/questions/array-compare/index.md
+++ b/content/questions/array-compare/index.md
@@ -29,4 +29,4 @@ console.log(a == b);
 
 When comparing either `a` or `b` to `c` using the equality operator (`==`), the JavaScript interpreter will attempt to use the array's built-in `toString` method to first convert the array to a string. For both `a` and `b`, the `a.toString()` method returns `'1,2,3'`. This is strictly equal to `c`, so both `a == c` and `b == c` are `true`!
 
-Two non-primitive values, like objects (including function and array) held by reference, When comparing two objects, so both the equality (`==`) and identity (`===`) operators will simply check whether the references match (not anything about the underlying values). In this case, `a` and `b` are references to different objects in memory, so `a == b` is `false`.
+Non-primitive values - that is, objects (including functions and arrays) are held by reference. When comparing two objects both the equality (`==`) and identity (`===`) operators will simply check whether the references match (the underlying values are not considered). In this case, `a` and `b` are references to different objects in memory, so `a == b` is `false`.

--- a/content/questions/array-length-alias-default-value/index.md
+++ b/content/questions/array-length-alias-default-value/index.md
@@ -39,7 +39,7 @@ The next line is where a lot of the action happens. It's generally best to first
 url.split('.').filter(Boolean);
 ```
 
-`url.split('.')` will split our `url` string by the `.` character, resulting in the following array: `['quiz', 'typeofnan', 'dev']`. applying `filter(Boolean)` on this array is the same as `filter(el => Boolean(el))`. Since all of the elements are truthy, `Boolean(el)` will always be `true`, meaning we don't actually filter anything out.
+`url.split('.')` will split our `url` string by the `.` character, resulting in the following array: `['quiz', 'typeofnan', 'dev']`. Applying `filter(Boolean)` on this array is the same as `filter(el => Boolean(el))`. Since all of the elements are truthy, `Boolean(el)` will always be `true`, meaning we don't actually filter anything out.
 
 The next bit applies object destructuring. Since our array is indeed an object, this is allowed.
 

--- a/content/questions/array-method-binding/index.md
+++ b/content/questions/array-method-binding/index.md
@@ -22,4 +22,6 @@ map(el => console.log(el));
 
 <!-- explanation -->
 
-`Object.bind` will bind the `this` keyword to the provided value (in this case, that's `[1, 2, 3]`).
+`['a', 'b', 'c'].map`, when called, will call `Array.prototype.map` with a `this` value of `['a', 'b', 'c']`. But, when used as a *reference*, rather than called, `['a', 'b', 'c'].map` is simply a reference to `Array.prototype.map`.
+
+`Function.prototype.bind` will bind the `this` of the function to the first parameter (in this case, that's `[1, 2, 3]`), and invoking `Array.prototype.map` with such a `this` results in those items being iterated over and logged.

--- a/content/questions/array-method-callbacks/index.md
+++ b/content/questions/array-method-callbacks/index.md
@@ -11,7 +11,8 @@ answers:
   - '1'
   - '0 // correct'
 ---
-What is returned from the following `console.log`?
+
+What gets logged in the following code?
 
 ```javascript
 let i = 0;
@@ -22,7 +23,6 @@ arr.forEach(() => i++);
 console.log(i);
 ```
 
-
 <!-- explanation -->
 
-Array methods like `map`, `filter`, `reduce`, `forEach`, etc take a callback as the first parameter, which is executed for every element in the array. The Array constructor, when given an integer between 0 and (2^32 - 1), will return a sparse array, which has a length property equal to the given integer. The returned array is "sparse" because its slots are empty (it does not contain actual elements equal to `undefined`).
+Array methods like `map`, `filter`, `reduce`, `forEach`, etc take a callback as the first parameter, which is executed for every element in the array. The Array constructor, when given an integer between 0 and (2<sup>32</sup> - 1), will return a sparse array, which has a length property equal to the given integer. The returned array is "sparse" because its slots are empty; it does not have any own-properties, other than `.length`. (In contrast, the array `[undefined]` *does* have an own-property of `0`, even though the value at that property is `undefined`.)

--- a/content/questions/array-method-slice/index.md
+++ b/content/questions/array-method-slice/index.md
@@ -10,19 +10,18 @@ answers:
   - '["Lemon", "Apple"]'
   - '["Orange", "Lemon"] // correct'
 ---
-Given an array of fruits, after slice method is applied, what will the result be?
 
----
+What will the value of `citrus` be in the below code?
+
 ```javascript
 var fruits = ['Banana', 'Orange', 'Lemon', 'Apple', 'Mango'];
 var citrus = fruits.slice(1, 3);
 ```
 
 <!-- explanation -->
-The reason why the result will be Orange and Lemon is that array index always starts at zero and the end index is "exclusive", meaning the returned array doesn't include that index. 
+The reason why the result will be `["Orange", "Lemon"]` is that the two parameters `.slice` accepts are:
 
-slice does not alter the original array. It returns a shallow copy of elements from the original array. Elements of the original array are copied into the returned array as follows:
+* The start index, inclusive
+* The end index, *exclusive* (the item at the end index will not be included in the result)
 
-For object references (and not the actual object), slice copies object references into the new array. Both the original and new array refer to the same object. If a referenced object changes, the changes are visible to both the new and original arrays.
-For strings, numbers and booleans (not String, Number and Boolean objects), slice copies the values into the new array. Changes to the string, number or boolean in one array do not affect the other array.
-If a new element is added to either array, the other array is not affected.
+`.slice` does not alter the original array. It returns a shallow copy of elements from the original array. It's only a shallow copy, so if an object is *mutated* in one of the arrays after slicing, the same object in the other array will have changed too, because the objects both point to the same location in memory. In contrast, *reassigning* any value in one array, primitive or otherwise, will have no effect on the other array. Simiarly, adding or removing items from one array will not affect the other.

--- a/content/questions/array-object-efficiency/index.md
+++ b/content/questions/array-object-efficiency/index.md
@@ -30,4 +30,4 @@ for (let i = 0; i < arr.length; i++) {
 
 <!-- explanation -->
 
-When `b` is being set, the `b[arr[i]]` property is set to the current index on each loop. When `a` is being set, the spread operator (`...`) will create a shallow copy of the accumulator object (`acc`) on each loop and additionally set the new property. This shallow copy is more expensive than not performing a shallow copy. Therefore, `b` is being set more efficiently.
+When `b` is being set, the `b[arr[i]]` property is set to the current index on each iteration. When `a` is being set, the spread syntax (`...`) will create a shallow copy of the accumulator object (`acc`) on each iteration and additionally set the new property. This shallow copy is more expensive than not performing a shallow copy; `a` requires the construction of 2 intermediate objects before the result is achieved, whereas `b` does not construct any intermediate objects. Therefore, `b` is being set more efficiently.

--- a/content/questions/array-pop/index.md
+++ b/content/questions/array-pop/index.md
@@ -21,6 +21,6 @@ var removedFromMyArray;
 ```
 
 <!-- explanation -->
-.pop() is used to "pop" a value off of the end of an array. We can store this "popped off" value by assigning it to a variable. In other words, .pop() removes the last element from an array and returns that element.
+`.pop()` is used to "pop" a value off of the end of an array. We can store this "popped off" value by assigning it to a variable. In other words, `.pop()` removes the last element from an array and returns that element.
 
 Any type of entry can be "popped" off of an array - numbers, strings, even nested arrays.

--- a/content/questions/arrays-sorting-reversing/index.md
+++ b/content/questions/arrays-sorting-reversing/index.md
@@ -43,7 +43,7 @@ Remember that the default [sort](https://developer.mozilla.org/en-US/docs/Web/Ja
 
 Next, `ar[1]` is found in the array `[5, 25]`, resulting in `[5, 25].indexOf(ar[1]) != -1` evaluating to `true`, leading to the second part of the statement (`ar.reverse()`) being evaluated.  Because `ar.reverse()` also works **in-place** and modifies the original array, `ar` is now `[7, 5, 3, 25, 1]`, which is the output of the second `console.log`.
 
-Because nothing is technically returned from a `console.log`, the first part effectively now evaluates to the following:
+Because `console.log` returns `undefined`, the first part effectively now evaluates to the following:
 
 ```javascript
 (
@@ -51,6 +51,6 @@ Because nothing is technically returned from a `console.log`, the first part eff
 ) || (ar[3] == 25 && console.log(ar));
 ```
 
-Only because `undefined` is falsy, the second half of the statement is now evaluated.  `ar[3] == 25` is true because the fourth element of the array is `25`, so this statement evaluates to `true` and `ar` is outputted in the third `console.log` as `[7, 5, 3, 25, 1]`.
+Because `undefined` is falsy, the second half of the statement is now evaluated.  `ar[3] == 25` is true because the fourth element of the array is `25`, so this statement evaluates to `true` and `ar` is outputted in the third `console.log` as `[7, 5, 3, 25, 1]`.
 
 Finally, we know that `ar1` is still pointing to the same array in memory as `ar`, so the fourth log `console.log(ar1);` simply outputs the same array again (`[7, 5, 3, 25, 1]`).

--- a/content/questions/arrow-functions/index.md
+++ b/content/questions/arrow-functions/index.md
@@ -12,7 +12,8 @@ answers:
   - 'undefined, Wooh // correct'
   - 'undefined, undefined'
 ---
-What is returned from the following `console.log`?
+
+What gets logged in the following code?
 
 ```javascript
 let dog = {
@@ -30,5 +31,5 @@ console.log(dog.getBreed(), dog.getSound());
 
 <!-- explanation -->
 
-Arrow functions do not bind their own this, instead, they inherit the one from the parent scope, which is called "lexical scoping". That is the reason that the this in getBreed refers to the global object.
+The `this` inside an arrow function does not depend on how the function was called. Instead, they inherit the `this` of the parent scope. This is called "lexical scoping". In sloppy mode, `this` on the top level refers to the global object, so `getBreed`'s `this.breed` refers to the `breed` property on the global object, which doesn't exist.
 

--- a/content/questions/async-await/index.md
+++ b/content/questions/async-await/index.md
@@ -2,7 +2,6 @@
 title: Async/Await
 tags:
   - es6
-  - javascript
   - promise
 order: 39
 date: Mon Oct 07 2019 09:40:20 GMT-0700 (Mountain Standard Time)
@@ -13,8 +12,7 @@ answers:
   - 'Something else'
 ---
 
-Consider the following async function and its output, what will be displayed to the console when
-calling the `f()` function?
+Consider the following async function and its output. What will be displayed to the console when calling the `f()` function?
 
 ```javascript
 async function f() {
@@ -33,12 +31,9 @@ f();
 
 <!-- explanation -->
 
-The function execution "pauses" at the line `await promise` and resumes when the promise settles,
-with result becoming its result. So the code above shows "done!" after one second.
+The function execution "pauses" at the line `await promise` and resumes when the promise settles, with the resolve value of the promise being assigned to `result`. So, the code above shows "done!" after one second.
 
-Let’s emphasize: `await` literally makes JavaScript wait until the promise settles, and then go on
-with the result. That doesn’t cost any CPU resources, because the engine can do other jobs
-meanwhile: execute other scripts, handle events etc.
+Let’s emphasize: `await` makes the current function pause until the promise settles, and then goes on with the result. This doesn’t cost any CPU resources, because the engine can do other jobs
+in the meantime: execute other scripts, handle events etc.
 
-It’s just a more elegant syntax of getting the promise result than `promise.then`,
-easier to read and write.
+`await` is mostly just a more elegant way to get the promise result than `promise.then`. `await` is easier to read and write, especially when multiple Promises need to be waited for, which would otherwise require somewhat-unwieldy `.then` chains.

--- a/content/questions/basic-recursion/index.md
+++ b/content/questions/basic-recursion/index.md
@@ -28,4 +28,4 @@ console.log(myFunc('Hello world'));
 
 <!-- explanation -->
 
-The first time we call the function, `str.length` is greater than 1 ("Hello World" is 11 characters), so we return the same function called on `str.slice(1)`, which is the string "ello World". We repeat this process until the string is only one character long: the character "d". We then log that character.
+The first time we call the function, `str.length` is greater than 1 ("Hello World" is 11 characters), so we return the same function called on `str.slice(1)`, which is the string "ello World". We repeat this process until the string is only one character long: the character "d", which gets returned to the initial call of `myFunc`. We then log that character.

--- a/content/questions/batman-v-superman/index.md
+++ b/content/questions/batman-v-superman/index.md
@@ -8,7 +8,7 @@ date: '2019-09-29'
 answers:
   - '"Batman"'
   - '"Superman"'
-  - '"BatmanSuperman" // correct'
+  - '"Batman" "Superman" // correct'
   - 'Nothing gets logged'
 ---
 

--- a/content/questions/callback-set-timeout/index.md
+++ b/content/questions/callback-set-timeout/index.md
@@ -19,32 +19,31 @@ Which of the following functions will add two variables and pass the sum to a ca
 // A
 const add = (x, y, callback) => {
   setTimeout(() => {
-    callback(x + y)
+    callback(x + y);
   }, 2);
-}
+};
 
 // B
 const add = (x, y, callback) => {
   setTimeout(() => {
-    callback(x + y)
+    callback(x + y);
   }, 2000);
-}
+};
 
 // C
 const add = (x, y, callback) => {
   setTimeout(() => {
-    callback(x + y, 2)
+    callback(x + y, 2);
   });
-}
-
+};
 
 // D
 const add = (x, y, callback) => {
   setTimeout(() => {
-    callback(x + y, 2000)
+    callback(x + y, 2000);
   });
-}
+};
 ```
 
 <!-- explanation -->
-The `setTimeout` function takes two variables: the first variable is the function to be executed and the second variable is the interval, in milliseconds, after which the function gets executed.
+The `setTimeout` function generally takes two variables: the first variable is the function to be executed, and the second variable is the interval, in milliseconds, after which the function gets executed.

--- a/content/questions/closure-and-hoisting/index.md
+++ b/content/questions/closure-and-hoisting/index.md
@@ -13,38 +13,38 @@ answers:
   - '24 Error 42'
 ---
 
-What would be the output of the following three `console.log`s.
+What would be the output of the following three `console.log`s?
 
 ```javascript
-  function withVar() {
-    const b = () => a;
-    var a = 24;
-    return b;
-  }
+function withVar() {
+  const b = () => a;
+  var a = 24;
+  return b;
+}
 
-  function withLet() {
-    const b = () => a;
-    let a = 24;
-    return b;
-  }
+function withLet() {
+  const b = () => a;
+  let a = 24;
+  return b;
+}
 
-  function changingValue() {
-    let a = 24;
-    const b = () => a;
-    a = 42;
-    return b;
-  }
+function changingValue() {
+  let a = 24;
+  const b = () => a;
+  a = 42;
+  return b;
+}
 
-  console.log(withVar()())  // ??
-  console.log(withLet()())  // ??
-  console.log(changingValue()())  // ??
+console.log(withVar()());  // ??
+console.log(withLet()());  // ??
+console.log(changingValue()());  // ??
 ```
 
 <!-- explanation -->
-Definition: "Closure" is said to occur when a function remembers and accesses its lexical scope, even when it is executed outside of that scope. [Definition by Kyle Simpson in YDKJS](https://github.com/getify/You-Dont-Know-JS/blob/1st-ed/scope%20%26%20closures/ch5.md).
+Definition: A "closure" is said to occur when a function remembers and accesses its lexical scope, even when it is executed outside of that scope. [Definition by Kyle Simpson in YDKJS](https://github.com/getify/You-Dont-Know-JS/blob/1st-ed/scope%20%26%20closures/ch5.md).
 
 When the internal functions `b` are returned from all the three functions, each function `b` gets a "closure" over the value of `a` defined in its parent function's scope. However, the value of `a` closed over by `b` in all cases is the "latest" value of `a`, or in other words, `b` has closure over the variable `a` itself, not its value. Hence, even when the value of `a` is changed, `b` always has the most recent value assigned to `a`.
 
-That is why, in `withVar`, even though `a` is undefined when `b` is first defined, however, by the time `b` is executed (inside the `console.log`), the value of `a` has been updated to `24`, and that is what is returned by `b` . Similarly, in `withLet`, there is no more "Temporal Dead Zone" for `a` by the time `b` is executed. And finally, the "updated" value of `a` is returned by `changingValue`.
+That is why, in `withVar`, even though `a` is undefined when `b` is first defined, however, by the time `b` is executed (inside the `console.log`), the value of `a` has been updated to `24`, and that is what is returned by `b` . Similarly, in `withLet`, the `a` variable is no longer in the "Temporal Dead Zone" by the time `b` is executed. And finally, the "updated" value of `a` is returned by `changingValue`.
 
 This example also demonstrates that the code inside a JS function does not "run" till the function is actually invoked (by using the parens, like `withVar()`). That is why, in `withVar` and `withLet`, even though function `b` returns `a`, which at that line is not declared at all. But the code actually only runs when `b` is invoked in their respective `console.log`s.

--- a/content/questions/combining-different-types/index.md
+++ b/content/questions/combining-different-types/index.md
@@ -14,11 +14,10 @@ answers:
 What gets logged in the following scenario?
 
 ```javascript
-
 console.log(2 + "1");
 console.log(2 - "1");
 ```
 
 <!-- explanation -->
 
-The first expression evaluates to `"21"` because the `+` operator defaults to string concatenation when used with a string. On the other hand, the `-` operator cannot act on strings so `"1"` gets converted to a number in the evaluation of the second expression.
+The first expression evaluates to `"21"` because the `+` operator results in string concatenation when either operand is a string. On the other hand, the `-` operator cannot act on strings so `"1"` gets converted to a number in the evaluation of the second expression.

--- a/content/questions/confusing-date/index.md
+++ b/content/questions/confusing-date/index.md
@@ -15,9 +15,9 @@ Consider the following code block which calls the Date constructor with 2 type o
 ```javascript
 let a = new Date("2019,1,1").toLocaleDateString();
 let b = new Date(2019,1,1).toLocaleDateString();
-console.log(a, b)
+console.log(a, b);
 ```
 
 <!-- explanation -->
 
-The Date constructor, `new Date()` creates a date object at a given date or the current date if no date is given. It can be called in many ways. If the Date constructor is passed as a string, JavaScript will attempt to interpret the string as a date. in this case, "2019,1,1" is interpreted as January 1, 2019. If the Date constructor is passed three numbers, the first value will be interpreted as the year, the second value the month, and the third the day. The catch here is JavaScript starts its month indexing at 0, so month `1` is February!
+The Date constructor, `new Date()`, creates a date object at a given date or the current date if no date is given. It can be called in many ways. If the Date constructor is passed as a string, JavaScript will attempt to interpret the string as a date. in this case, "2019,1,1" is interpreted as January 1, 2019. If the Date constructor is passed three numbers, the first value will be interpreted as the year, the second value the month, and the third the day. The catch here is JavaScript starts its month indexing at 0, so month `1` is February!

--- a/content/questions/console-log-fetch/index.md
+++ b/content/questions/console-log-fetch/index.md
@@ -18,4 +18,4 @@ console.log(fetch);
 
 <!-- explanation -->
 
-What happens when you `console.log(fetch)` really depends on your current environment. If you `console.log` it in a [browser version](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API#Browser_compatibility) that has a window.fetch method, you will log the fetch function. If you have an older browser, or are using the node environment, you may well get a reference error.
+What happens when you `console.log(fetch)` really depends on your current environment. If you `console.log` it in a [browser version](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API#Browser_compatibility) that has a `window.fetch` method, you will log the fetch function. If you have an older browser, or are not in a browser environment, you will receive a ReferenceError.

--- a/content/questions/copying-arrays/index.md
+++ b/content/questions/copying-arrays/index.md
@@ -34,8 +34,8 @@ mainArray.forEach(item => {
 
 <!-- explanation -->
 
-Option A just makes a reference to the array. In order to copy all the values from an array, you'll need to iterate through the array and copy each value over, which is what options B and C are doing.
+Option A just creates a new reference to the same array. In order to copy all the values from an array, you'll need to iterate through the array and copy each value over, which is what options B and C are doing.
 
-Keep in mind that methods B and C are making **shallow copies**. This works in the example because all the values are strings. If `mainArray` had objects nested within it, they wouldn't be copied over.
+Keep in mind that methods B and C are making **shallow copies**. This works in the example because all the values are strings. If `mainArray` had objects nested within it, the objects wouldn't be cloned; rather, both the original array and the cloned array would be holding a reference to the same object, so a change to the object in one array would result in a change to the object in the other array.
 
-Remember, Javascript passes by reference, not value. If you'd like to learn more about Arrays and how to create shallow copies (like this example shows), check out the [MDN Array Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
+Remember, JavaScript passes by reference, not value. If you'd like to learn more about arrays and how to create shallow copies (like this example shows), check out the [MDN Array Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)

--- a/content/questions/curly-q/index.md
+++ b/content/questions/curly-q/index.md
@@ -34,7 +34,7 @@ console.log(foo(), bar())
 
 Although the `foo()` and `bar()` functions above look almost identical, `bar()` returns
 `undefined`. This is because JavaScript automatically inserts semicolons after
-certain statements, including `return` statements.
+certain statements when they are followed by a newline, including `return` statements.
 
 Let's look at both functions and see where JavaScript inserts semicolons:
 

--- a/content/questions/delete-object-properties/index.md
+++ b/content/questions/delete-object-properties/index.md
@@ -11,7 +11,7 @@ answers:
   - 'D'
 ---
 
-Which of the following is a valid way to delete property `color` from the `car` object?
+Which of the following is a valid way to delete the property `color` from the `car` object?
 
 ```javascript
 const car = {
@@ -37,6 +37,6 @@ car.color.delete();
 
 You can use the JavaScript [delete operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete) to remove a property from an object.
 
-Both option A and D will give TypeError, because neither `car.delete` nor `car.color.delete` is a function.
+Both option A and D will give a TypeError, because neither `car.delete` nor `car.color.delete` is a function.
 
-Option C will give Reference error becuase `color` is not defined. However, `delete car['color']` will work, notice the quotation mark around `color`.
+Option C will give a ReferenceError becuase `color` is not defined. However, `delete car['color']` will work - notice the quotation marks around `color`.

--- a/content/questions/digit-with-dots-in-js/index.md
+++ b/content/questions/digit-with-dots-in-js/index.md
@@ -23,4 +23,8 @@ console.log(1..n); // ?
 
 This is not a syntax error. Rather, to call a method directly on a `Number.prototype`, two dots are required for it to not be interpreted as a decimal. In this case, `1..n` tries to access the property `n` on `1`, which is `undefined`. A practical example of this would be `1..toString()`, which would result in the string `"1"`.
 
+What's going on here is that a decimal point is permitted at the end of a number even if there are no decimal digits. `1.` is interpreted as a numeric literal equivalent to `1` - the dot is an optional decimal point, and is *not* indicating property access. If you add *another* `.`, the interpreter is forced to treat the second `.` as the property access operator.
+
+Another way to call a method on a numeric literal without the confusing `..` is to surround the number in parentheses, eg `(1).toString()`.
+
 To see more info on this notation, refer to: [Two dots to call a method](https://javascript.info/number#tostring-base).

--- a/content/questions/equality-operators-compare/index.md
+++ b/content/questions/equality-operators-compare/index.md
@@ -21,6 +21,6 @@ console.log((a == b) && (a === b));
 
 <!-- explanation -->
 
-The answer is `false`. `a == b` uses the "equality" operator, which will convert the operands to the same type prior to performing the comparison. In this case, `42 == '42'` wil become `42 === 42`, which is `true`.
+The answer is `false`. `a == b` uses the "equality" operator, which will convert the operands to the same type prior to performing the comparison. In this case, `42 == '42'` will become `42 === 42`, which is `true`.
 
 However, `a === b` uses the "identity" operator, and no such type conversion happens. Therefore, `42 === '42'` is `false`.  Hence, `(a == b) && (a === b)` becomes `true && false`, which is `false`.

--- a/content/questions/equality-operators/index.md
+++ b/content/questions/equality-operators/index.md
@@ -21,6 +21,6 @@ console.log(x == y);
 console.log(x === y);
 ```
 
-
 <!-- explanation -->
-The equality operator "==" first converts operands to the same types before doing a strict comparison so that's why "x == y" logs `true`. The identity operator "===" does a strict comparision also but without a type conversion. "x === y" therefore returns `false` because `x` and `y` do not share the same type.
+
+The equality operator `==` first converts operands to the same types before doing a strict comparison, so that's why `x == y` logs `true`. The identity operator "===" *only* carries out a strict comparision; there is no type conversion. `x === y` therefore returns `false` because `x` and `y` do not share the same type.

--- a/content/questions/flattened-array/index.md
+++ b/content/questions/flattened-array/index.md
@@ -11,14 +11,14 @@ answers:
   - '[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12]'
 ---
 
-Consider the following array get a with depth 5, what will get logged.
+Consider the following nested array. What will get logged?
 
 ```javascript
-const _array = [1,[2,[3,[4,[5,[6,[7],8],9],10]]],12]
-const result = _array.flat(5)
+const array = [1,[2,[3,[4,[5,[6,[7],8],9],10]]],12];
+const result = array.flat(5);
 console.log(result);
 ```
 
 <!-- explanation -->
 
-The Array#flat introduced in ES 2019 will flatten an array at the given depth level. If the depth is unknown, `Infinity` can be given. If no depth provided, the default depth will be 1. The value of depth starts from 1. 0 will return the array as it is.
+The `Array#flat` introduced in ES2019 will flatten an array up to the given depth level. If the depth is unknown, `Infinity` can be passed. If no depth is provided, the default depth will be 1. Passing 0 will return the array without modification.

--- a/content/questions/floating-point-precision/index.md
+++ b/content/questions/floating-point-precision/index.md
@@ -14,13 +14,12 @@ answers:
 Consider the following scenario. What gets logged?
 
 ```javascript
-const a = 0.1
-const b = 0.2
-const c = 0.3
+const a = 0.1;
+const b = 0.2;
+const c = 0.3;
 
-console.log(a + b === c)
+console.log(a + b === c);
 ```
-
 
 <!-- explanation -->
 

--- a/content/questions/global-local-scopes/index.md
+++ b/content/questions/global-local-scopes/index.md
@@ -27,10 +27,11 @@ var x = 5;
 
 <!-- explanation -->
 
-This will print out `undefined` and `10`. JavaScript will hoist the `var x` declaration within the function scope, but it will not hoist the initialization. The code is equivalent to:
+This will print out `undefined` and `10`. JavaScript will hoist the `var x` to the top of the function (or top level), but it will not hoist the assignment. The code is equivalent to:
 
 ```javascript
-var x = 5;
+var x;
+x = 5;
 
 (function() {
   var x;

--- a/content/questions/hoisting-race-to-the-top/index.md
+++ b/content/questions/hoisting-race-to-the-top/index.md
@@ -49,7 +49,7 @@ foo();
 
 <!-- explanation -->
 
-The answer is `first` for the first question. While both function declarations and variable declarations are hoisted, function declarations are hoisted first and then variables. Duplicate var declarations (but not asssignments!) are also ignored. So, what is interpreted by the Engine is:
+The answer is `first` for the first question. While both function declarations and variable declarations are hoisted, function declarations are hoisted first and then variables. Duplicate var declarations (but not asssignments!) are also ignored. So, what is interpreted by the engine is:
 
 ```javascript
 function immaBeOnTop() {

--- a/content/questions/identity-crisis/index.md
+++ b/content/questions/identity-crisis/index.md
@@ -14,7 +14,7 @@ answers:
   - 'false false false false'
 ---
 
-Consider the following comparison function and it's applications. What gets logged?
+Consider the following comparison function and its applications. What gets logged?
 
 ```javascript
 const compare = a => a === a;
@@ -27,6 +27,6 @@ console.log(compare([NaN]));
 
 <!-- explanation -->
 
-Out of all the built-in JavaScript objects, NaN aka Not-A-Number is the only one that compares unequal to every other value, including itself.
+Out of all JavaScript values, `NaN` aka Not-A-Number is the only one that compares unequal to every other value, including itself.
 
 Note that `[NaN]` is just a regular array that contains a single element so it will be always equal to itself.

--- a/content/questions/implicit-semicolon/index.md
+++ b/content/questions/implicit-semicolon/index.md
@@ -12,16 +12,33 @@ answers:
   - 'Good morning,'
   - 'undefined // correct'
 ---
-What does this snippet of code returns?
+
+What does this snippet of code return?
+
 ```javascript
-  function Greetings(name) {
-    return 
-      "Good morning, " + name
-  }
+function Greetings(name) {
+  return
+    "Good morning, " + name
+}
 
 Greetings("Giovanni")
 ```
 
-
 <!-- explanation -->
-When inserting a new line, javascript implicitly add a semicolon at the end of it. This means that the return statement would look like `return;` that evaluate to `undefined`.
+
+There are a number of keywords and syntax constructions which are not permitted to have newlines at a particular point. For example, `return`, `continue`, `break`, `throw`, and `yield`, if connected with another JavaScript token on the right-hand side, are forbidden to be separated from that token by a newline. For example, when `throw`ing something, the start of the thrown expression must be on the same line as the `throw`.
+
+When the interpreter is parsing JavaScript text and comes across one of these situations where a newline is forbidden, but a newline is found, and the preceding token (`return`, `continue`, etc) does *not* end with a semicolon, a semicolon will be inserted. So, the interpreter parses the code above into:
+
+```javascript
+function Greetings(name) {
+  return;
+    "Good morning, " + name;
+}
+
+Greetings("Giovanni");
+```
+
+Nothing is returned, so the return value is `undefined`.
+
+For more information about the rules for Automatic Semicolon Insertion, see [this question](https://stackoverflow.com/a/2846298).

--- a/content/questions/inceptionloop/index.md
+++ b/content/questions/inceptionloop/index.md
@@ -13,7 +13,7 @@ answers:
 In which direction will the following code scan an image?
 
 ```javascript
-const image = new Image;
+const image = new Image();
 const maxHeight = image.height + 1;
 const maxWidth = image.width + 1;
 
@@ -36,4 +36,4 @@ for (let i = 0; i < image.maxHeight; i++) {
 
 <!-- explanation -->
 
-Option A is the correct answer becuase value `i` will only update once all of the values of `j` have been processed.  So it will read across the row first before going to the next one below. Note all the pixel code is essentially a distraction.
+Option A is the correct answer becuase value `i` will only update once all of the values of `j` have been processed.  So, it will read across the row first before going to the next one below. Note all the pixel code is essentially a distraction.

--- a/content/questions/lexical-scope/index.md
+++ b/content/questions/lexical-scope/index.md
@@ -25,11 +25,10 @@ function invokePrintSomething() {
 var something = 2;
 
 invokePrintSomething();
-
 ```
-
-
 
 <!-- explanation -->
 
-Lexical scope holds that the RHS(Right Hand Side) reference to something in printSomething() will be resolved to the global variable something, which will result in value 2 being output.
+When a variable is referenced in JavaScript, the interpreter will try to find which binding it references by looking through the ancestor blocks and functions to see if a variable with that name is declared in that block or function. The nearest ancestor block (or the top level) which defines the variable with `const`, `let`, or `var` will be identified as the binding to use.
+
+Here, when `invokePrintSomething` is called and the `var something = 3` is found, the interpreter will see that the `something` is initialized with `var` in the same block, so the binding is to a variable local to `invokePrintSomething`. Then, when `printSomething` is called, and it comes across `console.log( something );`, it will look to its ancestor blocks to see where a variable named `something` is defined. The nearest (and only) ancestor block is the top level, with a `var something` which currently holds the value of `2`, so `2` gets logged.

--- a/content/questions/merge-two-arrays/index.md
+++ b/content/questions/merge-two-arrays/index.md
@@ -27,8 +27,6 @@ console.log([...a, ...b]);
 console.log(a + b);
 ```
 
-
-
 <!-- explanation -->
 
-Option C in this case is the right choice, because the arithmetic operator `+` only works for numeric values and not arrays. 
+Option C does not properly merge the arrays, because the arithmetic operator `+` only sensibly applies to strings and numbers. Any side of a `+` which refers to something other than a string or number will be converted into a string first, so this would result in the string `'1,2,3'` being concatenated with the string `'4,5,6'`, or `'1,2,34,5,6'`.

--- a/content/questions/object-clone-assign-mutation/index.md
+++ b/content/questions/object-clone-assign-mutation/index.md
@@ -11,7 +11,6 @@ answers:
   - 'Bob Changed bReturn'
   - 'Joe Changed aReturn // correct'
   - 'Bob Nested bReturn'
-
 ---
 
 Consider objects `a` and `b` below. What gets logged?
@@ -22,10 +21,10 @@ const a = {
   nestedField: {field: 'Nested'},
   functionField: () => 'aReturn'
 };
-const b = Object.assign({},a);
-b.stringField = 'Bob'
-b.nestedField.field = 'Changed'
-b.functionField = () => 'bReturn'
+const b = Object.assign({}, a);
+b.stringField = 'Bob';
+b.nestedField.field = 'Changed';
+b.functionField = () => 'bReturn';
 console.log(
   a.stringField,
   a.nestedField.field,
@@ -35,4 +34,6 @@ console.log(
 
 <!-- explanation -->
 
-Setting `b = Object.assign({},a);` will perform a shallow copy of object `a`. Since `b` is a shallow copy, any fields in `b` of the type "object", including Date objects, will be a ref to the field in `a`. However, unlike using `JSON.parse` and `JSON.stringify` to clone an object, `Object.assign` will work with non valid JSON values such as Functions and Symbols. See [MDN Description](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Examples) for a more detailed explanation.
+`b = Object.assign({}, a);` will create a shallow copy of object `a` and assign it to `b`. Since `b` is a shallow copy, any values in `b` of the type "object", including Date objects, will be referring to the same object that exists in the original `a` - a change to one of those in either `a` or `b` will result in the other object being changed as well, because they're the same reference.
+
+Note that, unlike using `JSON.parse` and `JSON.stringify` to deep clone an object, `Object.assign` will properly clone values on the top level of an object which can't be represented in JSON, such as functions and symbols. See [MDN Description](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Examples) for a more detailed explanation.

--- a/content/questions/object-clone-stringify-mutation/index.md
+++ b/content/questions/object-clone-stringify-mutation/index.md
@@ -11,7 +11,6 @@ answers:
   - 'Bob Changed'
   - 'Joe Changed'
   - 'Bob Nested'
-
 ---
 
 Consider objects `a` and `b` below. What gets logged?
@@ -22,8 +21,8 @@ const a = {
   nestedField: {field: 'Nested'}
 };
 const b = JSON.parse(JSON.stringify(a));
-b.stringField = 'Bob'
-b.nestedField.field = 'Changed'
+b.stringField = 'Bob';
+b.nestedField.field = 'Changed';
 console.log(
   a.stringField,
   a.nestedField.field
@@ -32,4 +31,4 @@ console.log(
 
 <!-- explanation -->
 
-Setting `b = JSON.parse(JSON.stringify(a))` will perform a deep copy of object `a`. `b` will not contain any references to `a` and thus mutating any fields in `b` will not affect any fields in `a`. This will, however, only properly copy valid JSON values. See [MDN Description](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Description) for a more detailed explanation.
+`b = JSON.parse(JSON.stringify(a))` will perform a deep copy of object `a` and assign it to `b`. `b` will not contain any references to `a` and thus mutating any fields in `b` will not affect any fields in `a`. This will, however, only properly copy valid JSON values. See [MDN Description](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Description) for a more detailed explanation.

--- a/content/questions/object-clone-stringify/index.md
+++ b/content/questions/object-clone-stringify/index.md
@@ -10,7 +10,6 @@ answers:
   - 'true true true false'
   - 'true true false true // correct'
   - 'false false false false'
-
 ---
 
 Consider objects `a` and `b` below. What gets logged?
@@ -33,4 +32,4 @@ console.log(
 
 <!-- explanation -->
 
-Setting `b = JSON.parse(JSON.stringify(a))` will perform a deep copy of object `a`. All primitive Javascript types (Boolean, String, and Number) will be copied correctly. However, non-valid JSON values (Date, undefined, Function, and other non-primitives) will not be copied correctly. In this instance, `JSON.stringify` will convert the Date object into an ISO string and it will remain a string when the stringified JSON is re-parsed. Since the two fields are different data types (Date object vs. string), the equality will yield false. See [MDN Description](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Description) for a more detailed explanation.
+Setting `b = JSON.parse(JSON.stringify(a))` will perform a deep copy of object `a`. All primitive JavaScript types (Boolean, String, and Number) will be copied correctly, as will plain objects and arrays. However, non-valid JSON values (undefined, Date, Function, and other class instances) will not be copied correctly. In this instance, `JSON.stringify` will convert the Date object into an ISO string and it will remain a string when the stringified JSON is re-parsed. Since the two fields are not the same type (one is a string, the other is a Date object), the `===` will evaluate to `false`. See [MDN Description](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Description) for a more detailed explanation.

--- a/content/questions/off-to-the-races/index.md
+++ b/content/questions/off-to-the-races/index.md
@@ -28,12 +28,12 @@ const p3 = new Promise((resolve, reject) =>
 
 Promise.race([p1, p2, p3])
   .then((result) => console.log(result))
-  .catch((reason) => console.log("Something went wrong..."))
+  .catch((reason) => console.log("Something went wrong..."));
 ```
 
 <!-- explanation -->
 
-Given an iterable of Promises, [`Promise.race()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/race) returns a Promise that resolves or rejects with the value of _the first
-promise that settles_.
+Given an iterable of Promises, [`Promise.race()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/race) returns a Promise that resolves or rejects with the value of the first
+Promise that settles (the first Promise that resolves or rejects).
 
 In this case, `p3` settles first, rejecting after 10 ms and falling into the `catch()` handler.

--- a/content/questions/operator-associativity/index.md
+++ b/content/questions/operator-associativity/index.md
@@ -25,6 +25,6 @@ console.log(3 > 2 > 1);
 
 The operators `<` and `>` follow left-to-right <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#Associativity">associativity</a>, meaning that they will be interpreted starting from the left. For demonstration, left-to-right evaluated expressions like `a OP b OP c` can be written as `(a OP b) OP c`.
 
-Following this scheme, the first expression becomes `(1 < 2) < 3`. The part in parenthesis evaluates to `true` leaving `true < 3`. As we are comparing numbers, `true` is then being coerced into the number `1`. Hence, the whole expression is true.
+Following this scheme, the first expression becomes `(1 < 2) < 3`. The part in parenthesis evaluates to `true` leaving `true < 3`. Because the right-hand side is a number, the `true` on the left-hand side is coerced into the number `1`. Hence, the whole expression evaluates to `true`.
 
-In the second example (visualized as `(3 > 2) > 1`), the first part `(3 > 2)` equals `true`. The remaining portion `true > 1` then gets converted to `1 > 1`. As `1` is not greater than itself, the whole expression evaluates to `false`.
+In the second example (visualized as `(3 > 2) > 1`), the first part `(3 > 2)` evaluates to `true`. The remaining portion `true > 1` then gets converted to `1 > 1`. As `1` is not greater than itself, the whole expression evaluates to `false`.

--- a/content/questions/pass-by-value/index.md
+++ b/content/questions/pass-by-value/index.md
@@ -40,5 +40,5 @@ console.log(c1[2]);
 
 <!-- explanation -->
 
-Because `a2` and `c2` refer to the same objects in memory as `a1` and `c1`, when their properties `hobby` and `[2]` were changed, those changes could also be seen through `a1` and `c1`.  The change made to `b2` was not changing a property, rather, replacing the `b2` variable itself.  Replacing a variable with a new value has no effect on the original value so `b1` remained unchanged.
+Because `a2` and `c2` refer to the same objects in memory as `a1` and `c1`, when their properties `hobby` and `[2]` were changed, those changes could also be seen through `a1` and `c1`.  The change made to `b2` was not changing a property, rather, replacing the `b2` variable itself.  Replacing a variable with a new value has no effect on the original value, so `b1` remained unchanged.
 

--- a/content/questions/pick-the-rotten-bean-in-an-array/index.md
+++ b/content/questions/pick-the-rotten-bean-in-an-array/index.md
@@ -10,18 +10,18 @@ answers:
   - 'Both of them'
 ---
 
-There is a rotten bean which looks different inside a basket. Which option below is the right way to pick the rotten bean?
+There is a rotten bean which looks different inside a basket. Which option below is the right way to create a new array containing only the rotten bean?
 
 ```javascript
-var basket = [0, 0, 0, 0, 9]
+var basket = [0, 0, 0, 0, 9];
 
 // A 
-basket.splice(4, 1)
+basket.splice(4, 1);
 
 // B
-basket.slice(4, 1)
+basket.slice(4, 1);
 ```
 
 <!-- explanation -->
 
-Option B in this case is not the right choice: the second parameter of the `slice` method must be an end point not a number of elements you want to delete.
+Option B in this case is not the right choice: the optional second parameter of the `slice` method must be the end index of the portion of the array you want to slice. (It's not the number of elements you want to delete.)

--- a/content/questions/prototypal-inheritance/index.md
+++ b/content/questions/prototypal-inheritance/index.md
@@ -30,4 +30,4 @@ console.log(dog.speak());
 
 <!-- explanation -->
 
-Every time we create a new `Dog` instance, we set the `speak` property to that instance to be a function returning the string `woof`. Since this is being set every time we create a new `Dog` instance, we never use the prototypal `speak` property on `Dog` that returns the `arf` string.
+Every time we create a new `Dog` instance, we set the `speak` property of that instance to be a function returning the string `woof`. Since this is being set every time we create a new `Dog` instance, the interpreter never has to look farther up the prototype chain to find a `speak` property. As a result, the `speak` method on `Dog.prototype.speak` never gets used.

--- a/content/questions/reduce-math/index.md
+++ b/content/questions/reduce-math/index.md
@@ -27,11 +27,11 @@ console.log(arr.reduce((agg, el) => agg + el(agg), 1));
 
 <!-- explanation -->
 
-In the array `reduce` method, our initial value is given in the second argument. In this case, that's `1`. We can then iterate over our functions as follows:
+With `Array#reduce`, the initial value of the aggregator (here, named `agg`) is given in the second argument. In this case, that's `1`. We can then iterate over our functions as follows:
 
-1 + 1 \* 1 = 2<br />
-2 + 2 \* 2 = 6<br />
-6 + 6 \* 3 = 24<br />
-24 + 24 \* 4 = 120
+1 + 1 \* 1 = 2 (value of aggregator in next iteration)<br />
+2 + 2 \* 2 = 6 (value of aggregator in next iteration)<br />
+6 + 6 \* 3 = 24 (value of aggregator in next iteration)<br />
+24 + 24 \* 4 = 120 (final value)
 
 So, 120 it is!

--- a/content/questions/reduce-object/index.md
+++ b/content/questions/reduce-object/index.md
@@ -25,9 +25,9 @@ console.log(result);
 
 <!-- explanation -->
 
-`Object.values` iterates through enumerable number keys in sequential order. This is the reason why the letters appear to sort themselves correctly.
+`Object.values` iterates through enumerable integer keys starting from 0 in sequential order. This is the reason why the letters appear to sort themselves correctly. (Very recently, it [*used*](https://stackoverflow.com/q/30076219) to be the case that `Object.values` did not guarantee the order of iteration over properties, but this is [no longer the case](https://github.com/tc39/proposal-for-in-order), as of December 2019.)
 
 The reduce method then takes two arguments: a reducer function and an initial value.
 - In this case, our reducer function is `(agg, el) => agg + el` and our initial value is `""`. 
-- In the reducer function, agg is the aggregator (which starts at the initial value) and el is each element In this case, as we iterate through the array, we add the current el to the aggregated value. 
-- If our array was `['a', 'b', 'c']`, then the reduce would be `a` the first time around, `ab` the second time, and finally would return `abc`.
+- In the reducer function, `agg` is the aggregator (which starts at the initial value) and `el` is an element in the array being iterated over. In this case, as we iterate through the array, we add the current `el` to the aggregated value.
+- If our array was `['a', 'b', 'c']`, then the aggregator would be `a` after the first iteration, `ab` the second time, and finally would return `abc`.

--- a/content/questions/set-uniqueness-ordering/index.md
+++ b/content/questions/set-uniqueness-ordering/index.md
@@ -12,7 +12,7 @@ answers:
   - '4 3'
 ---
 
-In the following problem, we use the `Set` object and spread operator to create a new array. What gets logged (to consider: Are items forced to be unique? Are they sorted?)
+In the following problem, we use the `Set` object and spread syntax to create a new array. What gets logged (to consider: Are items forced to be unique? Are they sorted?)
 
 ```javascript
 const arr = [...new Set([3, 1, 2, 3, 4])];
@@ -21,4 +21,4 @@ console.log(arr.length, arr[2]);
 
 <!-- explanation -->
 
-The `Set` object will force unique elements but will not change order. The resultant `arr` array will be `[3, 1, 2, 4]`, meaning `arr.length` is `4` and `arr[2]` (the third element of the array) is `2`.
+The `Set` object will force unique elements (duplicate elements already in the set are ignored), but will not change order. The resultant `arr` array will be `[3, 1, 2, 4]`, meaning `arr.length` is `4` and `arr[2]` (the third element of the array) is `2`.

--- a/content/questions/short-circuit-notifications/index.md
+++ b/content/questions/short-circuit-notifications/index.md
@@ -23,4 +23,4 @@ console.log(
 
 <!-- explanation -->
 
-Unfortunately, our short-circuit evaluation will not work as intended here: `notifications !== 1 && 's'` evaluates to `false`, meaning we will actually be logging `You have 1 notificationfalse`. If we want our snippet to work correctly, we could consider a ternary operator.
+Unfortunately, our short-circuit evaluation will not work as intended here: `notifications !== 1 && 's'` evaluates to `false`, meaning we will actually be logging `You have 1 notificationfalse`. If we want our snippet to work correctly, we could consider the conditional operator: `${notifications === 1 ? '' : 's'}`.

--- a/content/questions/spread-and-rename/index.md
+++ b/content/questions/spread-and-rename/index.md
@@ -12,7 +12,7 @@ answers:
   - 'Something else'
 ---
 
-Consider the following array of objects... okay, well one object. What happens when we spread that array and change the `firstName` property on the 0-index object?
+Consider the following array with a single object. What happens when we spread that array and change the `firstName` property on the 0-index object?
 
 ```javascript
 const arr1 = [{ firstName: 'James' }];
@@ -24,4 +24,4 @@ console.log(arr1);
 
 <!-- explanation -->
 
-Spread does a shallow copy of the array, meaning the object contained in `arr2` is still pointing to the same object in memory that the `arr1` object is pointing to. That there is only one object in memory and changing its `firstName` property will be reflected when logging `arr1` or `arr2`.
+Spread creates a shallow copy of the array, meaning the object contained in `arr2` is still pointing to the same object in memory that the `arr1` object is pointing to. So, changing the `firstName` property of the object in one array will be reflected by the object in the other array changing as well.

--- a/content/questions/string-interpolation/index.md
+++ b/content/questions/string-interpolation/index.md
@@ -13,14 +13,14 @@ answers:
   - "Soon we must all choose between what is wrong and what is difficult"
 ---
 
-What's the value of output?
+What's the value of `output`?
 
 ```javascript
-const output = `Soon we must all choose between what is ${[] ? 'right' : 'wrong'} and what is ${(() => false) ? 'difficult' : 'easy'}`
+const output = `Soon we must all choose between what is ${[] ? 'right' : 'wrong'} and what is ${(() => false) ? 'difficult' : 'easy'}`;
 ```
 
 <!-- explanation -->
 
-As [] is a truthy value, the above ternary condition returns 'right'.
+As `[]` is a truthy value, the first conditional evaluates to `'right'`.
 
-We just defined the method but not calling it. Function is a truthy value is Javascript, hence 'difficult' appends to the string.
+With the second conditional operator, we created a function `() => false`, but never called it. Functions, like all objects, are truthy values is JavaScript, hence `'difficult'` is the result.

--- a/content/questions/string-methods/index.md
+++ b/content/questions/string-methods/index.md
@@ -11,7 +11,7 @@ answers:
   - 'none'
 ---
 
-String methods are used to work with string in Javascript. Which method would be used to find a specified value and return the position of the match?
+String methods are used to work with string in JavaScript. Which method would be used to find a specified value and return the position of the match?
 
 For example, what method would tell you that `"bird"` is at position `4` in the following `word` string?
 

--- a/content/questions/template-literals/index.md
+++ b/content/questions/template-literals/index.md
@@ -13,7 +13,7 @@ answers:
   - stage-6
 ---
 
-Which transpiler language supports `Template Literals Syntax`?
+Which JavaScript language version supports template literals syntax, like below?
 
 ```javascript
 `helloworld - This is a string`
@@ -21,4 +21,6 @@ Which transpiler language supports `Template Literals Syntax`?
 
 <!-- explanation -->
 
-Template Literals Syntax will throw an error in (EI11,EI10). To fix this error use a transpiler of `es2015` with babel to resolve this issue. 
+Template literals are a feature of ES2015 (also known as ES6). In earlier environments, such as on IE11, this code will throw a SyntaxError.
+
+Like with all modern syntax, in order to write concise, readable code in the latest and greatest version of the language, while still permitting obsolete browsers to understand your code, use a transpiler like [Babel](https://babeljs.io/) to automatically translate your code down to ES5-compatible syntax.

--- a/content/questions/the-walking-dead/index.md
+++ b/content/questions/the-walking-dead/index.md
@@ -13,7 +13,7 @@ answers:
   - 'Something different is logged'
 ---
 
-What is the return of the following `console.log`?
+What is the output of the following `console.log`?
 
 ```javascript
 const a = { something: 1, someOtherThing: 2 };
@@ -28,7 +28,6 @@ const result = deleteSomething(a);
 console.log(result);
 ```
 
-
 <!-- explanation -->
 
-The output will be `undefined` because the `delete` operator has already deleted the property `something` before we attempt to return it. When try to access a non-existent object property, it will always return the value `undefined`. 
+The output will be `undefined` because the `delete` operator has already deleted the property `something` before we attempted to return it. When we try to access a non-existent object property, it will always return the value `undefined`. 

--- a/content/questions/this-keyword/index.md
+++ b/content/questions/this-keyword/index.md
@@ -21,17 +21,14 @@ myFunction();
 
 <!-- explanation -->
 
-In this case, `this` references the window. Why? Because it isn't tied to any specific object in order to reference so it references the closest object, which would globally be the window.
+In this case, `this` references the window. Why? Because `myFunction` was not called on an object, nor was a particular `this` set via `.bind` or `.call`. It's a plain standalone function which was invoked without a calling context, so inside it, `this` will refer to the global object (which is the `window`). (If we were in strict mode instead, the value of `this` when there is no calling context is `undefined`.)
 
-In most cases, the value of this is determined by how a function is called (runtime binding). It can't be set by assignment during execution, and it may be different each time the function is called.
+A function will have a `this` value other than the `window` or `undefined` when one of the following occurs:
 
-We can observe different behavior by binding `myFunction` to an object:
+* The function is called as a property of an object, eg `myObj.myFn()` will call `myFn` with a `this` value of `myObj`.
+* The function's `this` was bound to a particular object with `.bind` - eg `const boundFn = myFn.bind(obj); boundFn();` will result in `myFn` being called with a `this` value of `obj`.
+* The function was invoked via `.call`. Eg `myFn.call(obj)` will result in `myFn` being called with a `this` value of `obj`.
 
-```javascript
-function myFunction() {
-  console.log(this);
-}
-const obj = { name: 'Daffodil' };
-myFunction.bind(obj)();
-// { name: 'Daffodil' }
-```
+These are all applicable to full-fledged `function`s only - arrow functions, in contrast, always have their `this` inherit from the parent block.
+
+ A `this` value can't be set by assignment during execution, and it may be different each time the function is called.

--- a/content/questions/triple-plus/index.md
+++ b/content/questions/triple-plus/index.md
@@ -10,10 +10,10 @@ answers:
   - '8 5'
   - '7 5 // correct' 
   - '43 5'
-
+  - 'Syntax Error'
 ---
 
-Consider the following code block. What gets logged?
+Consider the following code block. What is the result?
 
 ```javascript
 let b = "4";
@@ -23,6 +23,25 @@ console.log(b +++ 3, b);
 
 <!-- explanation -->
 
-The Postfix Increment operator (`++`) takes precedence over the addition operator (`+`). The Postfix Increment operator also coerces strings to numbers. It uses the coerced number in the current expression, and the incremented value is not available until the following expression. So `"4"` is converted to `4`, then `3` is added. Then `4` is incremented to `5`, which is visible when `b` is passed as the second argument to `console.log`
+The Postfix Increment operator (`++`) takes precedence over the addition operator (`+`), and will coerce strings to numbers. The expression with the operator will evaluate to the coerced value, and (in line with the "Post" part of "Postfix") will increment the variable immediately afterwards.
 
-<a target="_blank" rel="noopener noreferrer" href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence">MDN Reference</a>
+The code block in the question is equivalent to
+
+```javascript
+let b = "4";
+console.log((b++) + 3, b);
+```
+
+First, `b` is coerced to a number, and the increment expression evaluates to that number:
+
+```javascript
+console.log((4) + 3, b);
+```
+
+`b` is then incremented from `4` to `5`. This resolves to:
+
+```javascript
+console.log(7, 5);
+```
+
+See <a target="_blank" rel="noopener noreferrer" href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence">MDN</a>'s article on operator precedence.

--- a/content/questions/type-coercion/index.md
+++ b/content/questions/type-coercion/index.md
@@ -23,4 +23,4 @@ Which of the following is an example of implicit coercion in JavaScript?
 
 <!-- explanation -->
 
-Some programming languages have a concept called type casting. This means that, if you want to convert one type to another type, you have to make the conversion explicit. In JavaScript there is a mechanism called _implicit coercion_, which converts types to other types as necessary. In this case, the addition operator `+` automatically converts `2019` to a string so it can be concatenated with the string `"Hello"`!
+Some programming languages have a concept called type casting. This means that, if you want to convert one type to another type, you have to make the conversion explicit. In JavaScript there is a mechanism called _implicit coercion_, which converts types to other types as necessary. In this case, the addition operator `+` automatically converts `2019` to a string so it can be concatenated with the string `"Hello"`. In contrast, `year.toString()` and `String(year)` are both *explicitly* converting it to a string.


### PR DESCRIPTION
Fixed a bunch of grammar and spelling mistakes.

Improved the wording of a few questions.

Improved and added to many of the explanations.

Made style more consistent - consistent style for the quiz is probably desirable. Given that almost all code in the quiz uses semicolons already, questions not related to ASI should probably have semicolons in the proper place.

Similarly, made the style of newlines in the Markdown more consistent across questions (eg, no leading or trailing newlines in code blocks, no more than a couple of newlines in a row).