### PR TITLE
Add US environment note for toLocaleDateString

### DIFF
--- a/content/questions/confusing-date/index.md
+++ b/content/questions/confusing-date/index.md
@@ -10,7 +10,7 @@ answers:
   - '1/1/2019 1/1/2019'
 ---
 
-Consider the following code block which calls the Date constructor with 2 type of values. What will be the output of `console.log`?
+Consider the following code block which calls the Date constructor with 2 type of values. In a US environment, what will be the output of `console.log`?
 
 ```javascript
 let a = new Date("2019,1,1").toLocaleDateString();


### PR DESCRIPTION
Correct answer is `1/1/2019 2/1/2019` but this is US-specific due to the nature of [`Date.prototype.toLocaleDateString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString)

For example, in en_GB the answer is different: `01/01/2019 01/02/2019`

![image](https://user-images.githubusercontent.com/14852491/73364186-012bbc00-42a2-11ea-8988-4da5fb0b537d.png)
