### PR TITLE
Fix variables in inception loop

### DIFF
--- a/content/questions/inceptionloop/index.md
+++ b/content/questions/inceptionloop/index.md
@@ -17,8 +17,8 @@ const image = new Image;
 const maxHeight = image.height + 1;
 const maxWidth = image.width + 1;
 
-for (let i = 0; i < image.maxHeight; i++) {
-  for (let j = 0; j < image.maxWidth; j++) {
+for (let i = 0; i < maxHeight; i++) {
+  for (let j = 0; j < maxWidth; j++) {
     // Obtaining values of pixels, assuming function getPixel(y, x) takes argument y as Y-coordinate and x as X-coordinate
     const pixel = getPixel(i, j);
     const pixelValues = { 


### PR DESCRIPTION
Use calculated variables `maxHeight` and `maxWidth` instead of undefined `image.maxHeight` and `image.maxWidth` properties