### PR TITLE
fix: typo

### DIFF
--- a/content/questions/template-literals/index.md
+++ b/content/questions/template-literals/index.md
@@ -3,12 +3,12 @@ title: Template Literals
 tags:
   - compiling
   - scripting
-  - ei11 
+  - ie11
   - babel
 order: 53
 date: Sat Oct 12 2019 17:08:35 GMT-0400 (Eastern Daylight Time)
-answers: 
-  - ecmascript 
+answers:
+  - ecmascript
   - es2015 // correct
   - stage-6
 ---
@@ -21,4 +21,4 @@ Which transpiler language supports `Template Literals Syntax`?
 
 <!-- explanation -->
 
-Template Literals Syntax will throw an error in (EI11,EI10). To fix this error use a transpiler of `es2015` with babel to resolve this issue. 
+Template Literals Syntax will throw an error in (IE11, IE10). To fix this error use a transpiler of `es2015` with babel to resolve this issue.


### PR DESCRIPTION
EI should be IE, referring to the browser.