### PR TITLE
fix: Manifest default attributes

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -85,11 +85,11 @@ module.exports = {
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: `Gatsby Starter Blog`,
-        short_name: `GatsbyJS`,
+        name: `TypeOfNaN JavaScript Quizzes`,
+        short_name: `TypeOfNaN`,
         start_url: `/`,
         background_color: `#ffffff`,
-        theme_color: `#663399`,
+        theme_color: `#f0db4f`,
         display: `minimal-ui`,
         icon: `content/assets/gatsby-icon.png`
       }


### PR DESCRIPTION
I noticed that manifest's common attributes, name, short-name and theme-color, were the default ones generated by Gatsby. 

![name](https://user-images.githubusercontent.com/24988697/81846656-1c71bd00-955b-11ea-9764-04939234e28c.png)
![theme_color](https://user-images.githubusercontent.com/24988697/81846659-1da2ea00-955b-11ea-9410-9c17284a28f1.png)