### PR TITLE
Fix typo in basic-recursion

### DIFF
--- a/content/questions/basic-recursion/index.md
+++ b/content/questions/basic-recursion/index.md
@@ -23,7 +23,7 @@ const myFunc = str => {
   return str;
 };
 
-console.log(myFunc('Hello world'));
+console.log(myFunc('Hello World'));
 ```
 
 <!-- explanation -->


### PR DESCRIPTION
The problem description and answer choices use the string `"Hello World"` with a capital `"W"`,
so I am fixing the typo in the code snippet.